### PR TITLE
Fixes #27 - UIRunner stops displaying stack traces

### DIFF
--- a/com.xored.f4.debug.ui/fan/FanConsoleTracker.fan
+++ b/com.xored.f4.debug.ui/fan/FanConsoleTracker.fan
@@ -83,8 +83,7 @@ class SourceSearchJob : Job
   override IStatus? run(IProgressMonitor? m)
   {
     
-    Obj? result := ((tryFindInProjects ?: 
-      tryFindByPath) ?: tryFindSourceModule) ?: tryFindType
+    Obj? result := ((tryFindInProjects ?: tryFindByPath) ?: tryFindSourceModule) ?: tryFindType
     
     if(result != null) 
       reportResults(result) 
@@ -94,7 +93,8 @@ class SourceSearchJob : Job
   
   private Obj? tryFindByPath()
   {
-    ResourcesPlugin.getWorkspace.getRoot.getFileForLocation(Path(link.fileName))
+    linkFileName := link.fileName
+    return linkFileName == null ? null : ResourcesPlugin.getWorkspace.getRoot.getFileForLocation(Path(linkFileName))
   }
   
   private Obj? tryFindInProjects()

--- a/com.xored.f4.debug.ui/fan/FanFileHyperlink.fan
+++ b/com.xored.f4.debug.ui/fan/FanFileHyperlink.fan
@@ -67,10 +67,11 @@ class FanHyperlink
     result := linkLine
     start := result.indexr("(") ?: 0
     end := result.indexr(")") ?: -1
+    if (start+1 >= result.size) return linkLine
     return result[start+1..<end]
   }
   
-  public once Str fileName()
+  public once Str? fileName()
   {
     txt := linkText[0..-1]
     if(isWin32 && txt[0] == '/') txt = txt[1..-1]
@@ -80,7 +81,8 @@ class FanHyperlink
       return matcher.group(1)
     }
     
-    throw ArgErr(ConsoleMessages.cantParseFile) //TODO: add normal logging
+    // not every line in a stack trace is a trace frame - sometimes there are multiline messages
+    return null
   }
   
   public once Str? projectName()

--- a/com.xored.f4.testing/fan/FanTestRunnerUI.fan
+++ b/com.xored.f4.testing/fan/FanTestRunnerUI.fan
@@ -42,7 +42,7 @@ class FanTestRunnerUI : AbstractTestRunnerUI, ITestElementResolver
   }
   
   private Bool isJavaSource(Str traceLine) {
-    FanHyperlink(traceLine).fileName.split('.').last == "java"
+    FanHyperlink(traceLine).fileName?.split('.')?.last == "java"
   }
   
   override Bool canFilterStack() {


### PR DESCRIPTION
This should fix #27 - UIRunner stops displaying stack traces