### PR TITLE
Fixes #33 - Default Java output folder `/fan/lib/fan/` is too deep

### DIFF
--- a/com.xored.f4.core/fan/manifest/FantomProject.fan
+++ b/com.xored.f4.core/fan/manifest/FantomProject.fan
@@ -99,7 +99,7 @@ const class FantomProject
     try {
       return (File.os(ResourcesPlugin.getWorkspace.getRoot
                 .getFolder(javaProject.getOutputLocation)
-                .getLocation.toFile.getAbsolutePath).uri.plusSlash + `fan/lib/fan/`).toFile
+                .getLocation.toFile.getAbsolutePath).uri.plusSlash).toFile
     } catch (Err e) {
       return baseDir
     }


### PR DESCRIPTION
Removed the fan/lib/fan suffix so users can control exactly where the .pod file is generated.