### PR TITLE
Clearing the output folder creates lots of told and untold problems. …

### DIFF
--- a/com.xored.f4.builder/fan/CompileFan.fan
+++ b/com.xored.f4.builder/fan/CompileFan.fan
@@ -172,8 +172,7 @@ class CompileFan : IScriptBuilder
       hasErrs = hasErrs || err.isErr
     }
     writeToLog //append empty line
-    if(hasErrs) clearOutFolder(fp)
-    else refreshPod(fp)
+    if(!hasErrs) refreshPod(fp)
     return hasErrs
   }
   


### PR DESCRIPTION
Clearing the `out` folder can have a devastating effect if it is shared with other projects. So prevent this from happening until a nicer solution is found.

…See https://github.com/xored/f4/issues/26#issuecomment-48725888