### PR TITLE
Fixes #32 Errors in build.fan are not reported

### DIFF
--- a/com.xored.f4.builder/fan/CompileFan.fan
+++ b/com.xored.f4.builder/fan/CompileFan.fan
@@ -37,7 +37,7 @@ using [java]org.eclipse.dltk.logconsole::LogConsoleType
 ** CompileFan
 **************************************************************************
 **
-** IScriptBuilder implementationt to build Fantom projects
+** IScriptBuilder implementation to build Fantom projects
 ** 
 class CompileFan : IScriptBuilder
 {

--- a/com.xored.f4.builder/fan/InternalBuilder.fan
+++ b/com.xored.f4.builder/fan/InternalBuilder.fan
@@ -37,7 +37,7 @@ class InternalBuilder : Builder
   
   override CompilerErr[] buildPod(|Str|? consumer)
   {
-    // Prepare temporaty output directory for pod building
+    // Prepare temporary output directory for pod building
     IPath statePath := FanCore.getDefault.getStateLocation
     IPath projectPath := statePath.append("compiler").append(fp.podName)
     JFile root := projectPath.toFile

--- a/com.xored.f4.builder/fan/ProblemReporter.fan
+++ b/com.xored.f4.builder/fan/ProblemReporter.fan
@@ -21,15 +21,17 @@ class ProblemReporter : ProblemCollector
   
   Void flush()
   {
-    if( resource.isAccessible) {
-      problems.toArray.each |IProblem p|
-      {
-        marker := resource.createMarker(F4Consts.buildProblem)
-        marker.setAttribute(IMarker.LINE_NUMBER, Integer(p.getSourceLineNumber))
-        marker.setAttribute(IMarker.MESSAGE, p.getMessage)
-        marker.setAttribute(IMarker.LOCATION, resource.getFullPath.toString)
-        marker.setAttribute(IMarker.SEVERITY, p.isWarning? IMarker.SEVERITY_WARNING: IMarker.SEVERITY_ERROR)
-      }
+    // make sure all errors are reported, even if the reported resource doesn't exist  
+    // see https://github.com/xored/f4/issues/32
+    append   := (Str?)      (resource.isAccessible ? null     : ": ${resource.getFullPath.toString}")
+    resource := (IResource) (resource.isAccessible ? resource : resource.getProject.getFile("build.fan"))
+    problems.toArray.each |IProblem p|
+    {
+      marker := resource.createMarker(F4Consts.buildProblem)
+      marker.setAttribute(IMarker.LINE_NUMBER, Integer(p.getSourceLineNumber))
+      marker.setAttribute(IMarker.MESSAGE, append == null ? p.getMessage : p.getMessage + append)
+      marker.setAttribute(IMarker.LOCATION, resource.getFullPath.toString)
+      marker.setAttribute(IMarker.SEVERITY, p.isWarning? IMarker.SEVERITY_WARNING: IMarker.SEVERITY_ERROR)
     }
     problems.clear
   }


### PR DESCRIPTION
compiler::InitInput.findFiles() reports CompilerErrs against resDirs that can't be found.
But because these dirs didn't exist, they weren't accessible and weren't reported.

The fix is to report ALL problems, resolving against 'build.fan' if they don't exist.