### PR TITLE
Fixes #28 Default Working Directory for Run Configurations

### DIFF
--- a/com.xored.f4.jdt.launching/fan/internal/TargetJavaConfig.fan
+++ b/com.xored.f4.jdt.launching/fan/internal/TargetJavaConfig.fan
@@ -25,12 +25,13 @@ class JavaLaunchUtil
     Str mainLaunchType
     )
   {
-    scriptName := AbstractScriptLaunchConfigurationDelegate.getScriptProjectName(src)
+    scriptName	:= AbstractScriptLaunchConfigurationDelegate.getScriptProjectName(src)
     interpreter := ScriptRuntime.computeInterpreterInstall(src)
-    fanHome := PathUtil.fanHome(interpreter.getInstallLocation.getPath)
+    fanHome 	:= PathUtil.fanHome(interpreter.getInstallLocation.getPath)		
+    projHome	:= PathUtil.resolvePath(AbstractScriptLaunchConfigurationDelegate.getProject(src).getFullPath)
     
     target.setAttribute(IJavaLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, 
-      src.getAttribute(ScriptLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, fanHome.toFile.osPath))
+      src.getAttribute(ScriptLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, projHome.osPath))
     target.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, scriptName)
     target.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, mainLaunchType)
     


### PR DESCRIPTION
> It would also be good idea to replace defaults in: FanTabGroup, it uses ScriptArgumentsTab with default WorkingDirectoryBlock. - Andrey

The docs for [IJavaLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY](http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Flaunching%2FIJavaLaunchConfigurationConstants.html&anchor=ATTR_WORKING_DIRECTORY) say:

> When unspecified, the working directory defaults to the project associated with a launch configuration.

which is the desired behaviour. Um, so what else needs doing?

And when testing it - it all seems to work!
