### PR TITLE
Feature/81 test inheritance from dependant pods 

### DIFF
--- a/com.xored.f4.core/fan/util/ParseUtil.fan
+++ b/com.xored.f4.core/fan/util/ParseUtil.fan
@@ -17,14 +17,13 @@ using f4model
 **
 class ParseUtil : TypeUtil
 {
-  static Bool inherits(IFanType? t, Str base, IFanNamespace ns)
+  static Bool inherits(IFanType? t, Str qNameBase, IFanNamespace ns)
   {
     t != null && t.inheritance.any |Str baseName -> Bool|
     {
-      baseName == base || 
-      inherits(ns.findType(baseName), base, ns)
+      baseType := ns.findType(baseName)	
+      return baseType.qname == qNameBase || inherits(baseType, qNameBase, ns)
     }
-    
   }
   
   static Str[] typeNames(ISourceModule module)

--- a/com.xored.f4.testing/fan/FanTestingLaunchShortcut.fan
+++ b/com.xored.f4.testing/fan/FanTestingLaunchShortcut.fan
@@ -66,7 +66,7 @@ class FanTestingLaunchShortcut : AbstractScriptLaunchShortcut
     ns := ParseUtil.ns(sourceModule)   
     typeName := ParseUtil.typeNames(sourceModule).find  
     {
-      ParseUtil.inherits(ns.findType(it), "Test", ns)  
+      ParseUtil.inherits(ns.findType(it), "sys::Test", ns)  
     } ?: ""
     if (typeName=="") return false   
     return true
@@ -85,7 +85,7 @@ class FanTestingLaunchShortcut : AbstractScriptLaunchShortcut
       ns := ParseUtil.ns(sourceModule)
       typeName = ParseUtil.typeNames(sourceModule).find 
       {
-        ParseUtil.inherits(ns.findType(it), "Test", ns) 
+        ParseUtil.inherits(ns.findType(it), "sys::Test", ns) 
       } ?: ""
     }
     

--- a/com.xored.f4.testing/fan/FanTestingTabGroup.fan
+++ b/com.xored.f4.testing/fan/FanTestingTabGroup.fan
@@ -115,7 +115,7 @@ class FanTestingMainTab : MainLaunchConfigurationTab
       return false
     }
     
-    if(!ParseUtil.inherits(type, "Test", ns))
+    if(!ParseUtil.inherits(type, "sys::Test", ns))
     {
       setErrorMessage("Class $className does not extend 'sys::Test' class")
       return false


### PR DESCRIPTION
Fixes #81
ParseUtil.inherits() didn't recognise qualified type names (as returned from dependant pods)